### PR TITLE
feat: add support for offset

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -25,7 +25,7 @@ Next to Prometheus, Alertmanager, node-exporter, prometheus-adapter and Grafana,
 git clone git@github.com:prometheus-operator/kube-prometheus.git
 cd kube-prometheus
 # Deploy the CRDs and the Prometheus Operator
-kubectl apply -f ./manifests/setup
+kubectl apply --server-side=true -f ./manifests/setup
 # Deploy all the resource like Prometheus, StatefulSets, and Deployments.
 kubectl apply -f ./manifests/
 ```

--- a/examples/kubernetes/manifests/slos/slo-prometheus-query-errors-with-offset.yaml
+++ b/examples/kubernetes/manifests/slos/slo-prometheus-query-errors-with-offset.yaml
@@ -1,0 +1,20 @@
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: prometheus-query-errors-with-offset
+  namespace: monitoring
+spec:
+  description: ""
+  indicator:
+    ratio:
+      errors:
+        metric: prometheus_http_requests_total{job="prometheus-k8s",handler=~"/api/v1/query.*",code=~"5.."} offset 1m
+      grouping:
+      - handler
+      total:
+        metric: prometheus_http_requests_total{job="prometheus-k8s",handler=~"/api/v1/query.*"} offset 1m
+  target: "99"
+  window: 2w

--- a/kubernetes/api/v1alpha1/servicelevelobjective_types.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types.go
@@ -416,12 +416,14 @@ func (in *ServiceLevelObjective) Internal() (slo.Objective, error) {
 
 		ratio = &slo.RatioIndicator{
 			Errors: slo.Metric{
-				Name:          errorVec.Name,
-				LabelMatchers: errorMatchers,
+				Name:           errorVec.Name,
+				LabelMatchers:  errorMatchers,
+				OriginalOffset: &errorVec.OriginalOffset,
 			},
 			Total: slo.Metric{
-				Name:          totalVec.Name,
-				LabelMatchers: totalVec.LabelMatchers,
+				Name:           totalVec.Name,
+				LabelMatchers:  totalVec.LabelMatchers,
+				OriginalOffset: &totalVec.OriginalOffset,
 			},
 			Grouping: in.Spec.ServiceLevelIndicator.Ratio.Grouping,
 		}
@@ -463,12 +465,14 @@ func (in *ServiceLevelObjective) Internal() (slo.Objective, error) {
 
 		latency = &slo.LatencyIndicator{
 			Success: slo.Metric{
-				Name:          successVec.Name,
-				LabelMatchers: successMatchers,
+				Name:           successVec.Name,
+				LabelMatchers:  successMatchers,
+				OriginalOffset: &successVec.OriginalOffset,
 			},
 			Total: slo.Metric{
-				Name:          totalVec.Name,
-				LabelMatchers: totalMatchers,
+				Name:           totalVec.Name,
+				LabelMatchers:  totalMatchers,
+				OriginalOffset: &totalVec.OriginalOffset,
 			},
 			Grouping: in.Spec.ServiceLevelIndicator.Latency.Grouping,
 		}
@@ -500,8 +504,9 @@ func (in *ServiceLevelObjective) Internal() (slo.Objective, error) {
 		latencyNative = &slo.LatencyNativeIndicator{
 			Latency: latency,
 			Total: slo.Metric{
-				Name:          totalVec.Name,
-				LabelMatchers: totalMatchers,
+				Name:           totalVec.Name,
+				LabelMatchers:  totalMatchers,
+				OriginalOffset: &totalVec.OriginalOffset,
 			},
 			Grouping: in.Spec.ServiceLevelIndicator.LatencyNative.Grouping,
 		}
@@ -527,8 +532,9 @@ func (in *ServiceLevelObjective) Internal() (slo.Objective, error) {
 
 		boolGauge = &slo.BoolGaugeIndicator{
 			Metric: slo.Metric{
-				Name:          vec.Name,
-				LabelMatchers: matchers,
+				Name:           vec.Name,
+				LabelMatchers:  matchers,
+				OriginalOffset: &vec.OriginalOffset,
 			},
 			Grouping: in.Spec.ServiceLevelIndicator.BoolGauge.Grouping,
 		}

--- a/kubernetes/api/v1alpha1/servicelevelobjective_types_test.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types_test.go
@@ -8,16 +8,13 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/yaml"
 
 	"github.com/pyrra-dev/pyrra/kubernetes/api/v1alpha1"
 	"github.com/pyrra-dev/pyrra/slo"
 )
-
-func durationPtr(d time.Duration) *time.Duration {
-	return &d
-}
 
 var examples = []struct {
 	config    string
@@ -69,7 +66,7 @@ spec:
 							{Type: labels.MatchRegexp, Name: "code", Value: "5.."},
 							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "http_requests_total"},
 						},
-						OriginalOffset: durationPtr(0 * time.Second),
+						OriginalOffset: ptr.To(0 * time.Second),
 					},
 					Total: slo.Metric{
 						Name: "http_requests_total",
@@ -77,7 +74,7 @@ spec:
 							{Type: labels.MatchEqual, Name: "job", Value: "metrics-service-thanos-receive-default"},
 							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "http_requests_total"},
 						},
-						OriginalOffset: durationPtr(0 * time.Second),
+						OriginalOffset: ptr.To(0 * time.Second),
 					},
 				},
 			},
@@ -126,7 +123,7 @@ spec:
 							{Type: labels.MatchRegexp, Name: "grpc_code", Value: "Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss"},
 							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "grpc_server_handled_total"},
 						},
-						OriginalOffset: durationPtr(0 * time.Second),
+						OriginalOffset: ptr.To(0 * time.Second),
 					},
 					Total: slo.Metric{
 						Name: "grpc_server_handled_total",
@@ -136,7 +133,7 @@ spec:
 							{Type: labels.MatchEqual, Name: "grpc_method", Value: "Write"},
 							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "grpc_server_handled_total"},
 						},
-						OriginalOffset: durationPtr(0 * time.Second),
+						OriginalOffset: ptr.To(0 * time.Second),
 					},
 				},
 			},
@@ -188,7 +185,7 @@ spec:
 							{Type: labels.MatchRegexp, Name: "code", Value: "5.."},
 							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "http_requests_total"},
 						},
-						OriginalOffset: durationPtr(10 * time.Minute),
+						OriginalOffset: ptr.To(10 * time.Minute),
 					},
 					Total: slo.Metric{
 						Name: "http_requests_total",
@@ -196,7 +193,7 @@ spec:
 							{Type: labels.MatchEqual, Name: "job", Value: "metrics-service-thanos-receive-default"},
 							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "http_requests_total"},
 						},
-						OriginalOffset: durationPtr(10 * time.Minute),
+						OriginalOffset: ptr.To(10 * time.Minute),
 					},
 				},
 			},
@@ -243,7 +240,7 @@ spec:
 							{Type: labels.MatchEqual, Name: "le", Value: "1"},
 							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "http_request_duration_seconds_bucket"},
 						},
-						OriginalOffset: durationPtr(0 * time.Second),
+						OriginalOffset: ptr.To(0 * time.Second),
 					},
 					Total: slo.Metric{
 						Name: "http_request_duration_seconds_count",
@@ -252,7 +249,7 @@ spec:
 							{Type: labels.MatchRegexp, Name: "code", Value: "2.."},
 							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "http_request_duration_seconds_count"},
 						},
-						OriginalOffset: durationPtr(0 * time.Second),
+						OriginalOffset: ptr.To(0 * time.Second),
 					},
 				},
 			},
@@ -300,7 +297,7 @@ spec:
 							{Type: labels.MatchEqual, Name: "le", Value: "0.6"},
 							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "grpc_server_handling_seconds_bucket"},
 						},
-						OriginalOffset: durationPtr(0 * time.Second),
+						OriginalOffset: ptr.To(0 * time.Second),
 					},
 					Total: slo.Metric{
 						Name: "grpc_server_handling_seconds_count",
@@ -310,7 +307,7 @@ spec:
 							{Type: labels.MatchEqual, Name: "grpc_method", Value: "Write"},
 							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "grpc_server_handling_seconds_count"},
 						},
-						OriginalOffset: durationPtr(0 * time.Second),
+						OriginalOffset: ptr.To(0 * time.Second),
 					},
 				},
 			},
@@ -358,7 +355,7 @@ spec:
 							{Type: labels.MatchEqual, Name: "le", Value: "0.5"},
 							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "nginx_ingress_controller_request_duration_seconds_bucket"},
 						},
-						OriginalOffset: durationPtr(0 * time.Second),
+						OriginalOffset: ptr.To(0 * time.Second),
 					},
 					Total: slo.Metric{
 						Name: "nginx_ingress_controller_request_duration_seconds_count",
@@ -367,7 +364,7 @@ spec:
 							{Type: labels.MatchEqual, Name: "path", Value: "/"},
 							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "nginx_ingress_controller_request_duration_seconds_count"},
 						},
-						OriginalOffset: durationPtr(0 * time.Second),
+						OriginalOffset: ptr.To(0 * time.Second),
 					},
 				},
 			},
@@ -411,14 +408,14 @@ spec:
 						LabelMatchers: []*labels.Matcher{
 							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "prometheus_operator_reconcile_errors_total"},
 						},
-						OriginalOffset: durationPtr(0 * time.Second),
+						OriginalOffset: ptr.To(0 * time.Second),
 					},
 					Total: slo.Metric{
 						Name: "prometheus_operator_reconcile_operations_total",
 						LabelMatchers: []*labels.Matcher{
 							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "prometheus_operator_reconcile_operations_total"},
 						},
-						OriginalOffset: durationPtr(0 * time.Second),
+						OriginalOffset: ptr.To(0 * time.Second),
 					},
 				},
 			},

--- a/slo/promql.go
+++ b/slo/promql.go
@@ -13,7 +13,7 @@ import (
 
 // QueryTotal returns a PromQL query to get the total amount of requests served during the window.
 func (o Objective) QueryTotal(window model.Duration) string {
-	expr, err := parser.ParseExpr(`sum by (grouping) (metric{})`)
+	expr, err := parser.ParseExpr(`sum by (grouping) (metric{} offset 1ms)`)
 	if err != nil {
 		return ""
 	}
@@ -75,7 +75,7 @@ func (o Objective) QueryTotal(window model.Duration) string {
 func (o Objective) QueryErrors(window model.Duration) string {
 	switch o.IndicatorType() {
 	case Ratio:
-		expr, err := parser.ParseExpr(`sum by (grouping) (metric{})`)
+		expr, err := parser.ParseExpr(`sum by (grouping) (metric{} offset 1ms)`)
 		if err != nil {
 			return ""
 		}
@@ -103,7 +103,7 @@ func (o Objective) QueryErrors(window model.Duration) string {
 
 		return expr.String()
 	case Latency:
-		expr, err := parser.ParseExpr(`sum by (grouping) (metric{matchers="total"}) - sum by (grouping) (errorMetric{matchers="errors"})`)
+		expr, err := parser.ParseExpr(`sum by (grouping) (metric{matchers="total"} offset 1ms) - sum by (grouping) (errorMetric{matchers="errors"} offset 2ms)`)
 		if err != nil {
 			return ""
 		}
@@ -148,7 +148,7 @@ func (o Objective) QueryErrors(window model.Duration) string {
 
 		return expr.String()
 	case LatencyNative:
-		expr, err := parser.ParseExpr(`sum by (grouping) (metric{matchers="total"}) - sum by (grouping) (errorMetric{matchers="errors"})`)
+		expr, err := parser.ParseExpr(`sum by (grouping) (metric{matchers="total"} offset 1ms) - sum by (grouping) (errorMetric{matchers="errors"} offset 2ms)`)
 		if err != nil {
 			return ""
 		}
@@ -186,7 +186,7 @@ func (o Objective) QueryErrors(window model.Duration) string {
 
 		return expr.String()
 	case BoolGauge:
-		expr, err := parser.ParseExpr(`sum by (grouping) (errorMetric{matchers="errors"}) - sum by (grouping) (metric{matchers="total"})`)
+		expr, err := parser.ParseExpr(`sum by (grouping) (errorMetric{matchers="errors"} offset 2ms) - sum by (grouping) (metric{matchers="total"} offset 1ms)`)
 		if err != nil {
 			return ""
 		}
@@ -243,9 +243,9 @@ func (o Objective) QueryErrorBudget() string {
   (1 - 0.696969)
   -
   (
-    sum(errorMetric{matchers="errors"} or vector(0))
+    sum(errorMetric{matchers="errors"} offset 2ms or vector(0))
     /
-    sum(metric{matchers="total"})
+    sum(metric{matchers="total"} offset 1ms)
   )
 )
 /
@@ -300,9 +300,9 @@ func (o Objective) QueryErrorBudget() string {
   -
   (
     1 -
-    sum(errorMetric{matchers="errors"} or vector(0))
+    sum(errorMetric{matchers="errors"} offset 2ms or vector(0))
     /
-    sum(metric{matchers="total"})
+    sum(metric{matchers="total"} offset 1ms)
   )
 )
 /
@@ -377,10 +377,10 @@ func (o Objective) QueryErrorBudget() string {
   (1 - 0.696969)
   -
   (
-    (sum by (grouping) (metric{matchers="total"}) -
-    sum by (grouping) (errorMetric{matchers="errors"}))
+    (sum by (grouping) (metric{matchers="total"} offset 1ms) -
+    sum by (grouping) (errorMetric{matchers="errors"} offset 2ms))
     /
-    sum by (grouping) (metric{matchers="total"})
+    sum by (grouping) (metric{matchers="total"} offset 1ms)
   )
 )
 /
@@ -480,7 +480,7 @@ func (o Objective) QueryBurnrate(timerange time.Duration, groupingMatchers []*la
 		return "", fmt.Errorf("objective misses indicator")
 	}
 
-	expr, err := parser.ParseExpr(`metric{}`)
+	expr, err := parser.ParseExpr(`metric{} offset 1ms`)
 	if err != nil {
 		return "", err
 	}
@@ -525,8 +525,10 @@ func (o Objective) QueryBurnrate(timerange time.Duration, groupingMatchers []*la
 type objectiveReplacer struct {
 	metric        string
 	matchers      []*labels.Matcher
+	offset        *time.Duration
 	errorMetric   string
 	errorMatchers []*labels.Matcher
+	errorOffset   *time.Duration
 	grouping      []string
 	window        time.Duration
 	target        float64
@@ -554,6 +556,23 @@ func (r objectiveReplacer) replace(node parser.Node) {
 			n.Name = r.errorMetric
 		} else {
 			n.Name = r.metric
+		}
+		if n.OriginalOffset == 2*time.Millisecond {
+			// 2ms is the placeholder for the errorOffset
+			if r.errorOffset != nil {
+				n.OriginalOffset = *r.errorOffset
+			} else {
+				n.OriginalOffset = 0
+			}
+		} else if n.OriginalOffset == 1*time.Millisecond {
+			// 1ms is the placeholder for the offset
+			if r.offset != nil {
+				n.OriginalOffset = *r.offset
+			} else {
+				n.OriginalOffset = 0
+			}
+		} else {
+			n.OriginalOffset = 0
 		}
 		if len(n.LabelMatchers) > 1 {
 			for _, m := range n.LabelMatchers {
@@ -591,7 +610,7 @@ func (r objectiveReplacer) replace(node parser.Node) {
 func (o Objective) RequestRange(timerange time.Duration) string {
 	switch o.IndicatorType() {
 	case Ratio:
-		expr, err := parser.ParseExpr(`sum by (group) (rate(metric{}[1s])) > 0`)
+		expr, err := parser.ParseExpr(`sum by (group) (rate(metric{}[1s] offset 1ms)) > 0`)
 		if err != nil {
 			return err.Error()
 		}
@@ -606,6 +625,7 @@ func (o Objective) RequestRange(timerange time.Duration) string {
 		objectiveReplacer{
 			metric:   o.Indicator.Ratio.Total.Name,
 			matchers: matchers,
+			offset:   o.Indicator.Ratio.Total.OriginalOffset,
 			grouping: groupingLabels(
 				o.Indicator.Ratio.Errors.LabelMatchers,
 				matchers,
@@ -616,7 +636,7 @@ func (o Objective) RequestRange(timerange time.Duration) string {
 
 		return expr.String()
 	case Latency:
-		expr, err := parser.ParseExpr(`sum(rate(metric{}[1s]))`)
+		expr, err := parser.ParseExpr(`sum(rate(metric{}[1s] offset 1ms))`)
 		if err != nil {
 			return err.Error()
 		}
@@ -624,14 +644,16 @@ func (o Objective) RequestRange(timerange time.Duration) string {
 		objectiveReplacer{
 			metric:        o.Indicator.Latency.Total.Name,
 			matchers:      o.Indicator.Latency.Total.LabelMatchers,
+			offset:        o.Indicator.Latency.Total.OriginalOffset,
 			errorMetric:   o.Indicator.Latency.Success.Name,
 			errorMatchers: o.Indicator.Latency.Success.LabelMatchers,
+			errorOffset:   o.Indicator.Latency.Success.OriginalOffset,
 			window:        timerange,
 		}.replace(expr)
 
 		return expr.String()
 	case LatencyNative:
-		expr, err := parser.ParseExpr(`sum(histogram_count(rate(metric{}[1s])))`)
+		expr, err := parser.ParseExpr(`sum(histogram_count(rate(metric{}[1s] offset 1ms)))`)
 		if err != nil {
 			return err.Error()
 		}
@@ -639,12 +661,13 @@ func (o Objective) RequestRange(timerange time.Duration) string {
 		objectiveReplacer{
 			metric:   o.Indicator.LatencyNative.Total.Name,
 			matchers: o.Indicator.LatencyNative.Total.LabelMatchers,
+			offset:   o.Indicator.LatencyNative.Total.OriginalOffset,
 			window:   timerange,
 		}.replace(expr)
 
 		return expr.String()
 	case BoolGauge:
-		expr, err := parser.ParseExpr(`sum by(group) (count_over_time(metric{matchers="total"}[1s])) / 86400`)
+		expr, err := parser.ParseExpr(`sum by(group) (count_over_time(metric{matchers="total"}[1s] offset 1ms)) / 86400`)
 		if err != nil {
 			return err.Error()
 		}
@@ -653,6 +676,7 @@ func (o Objective) RequestRange(timerange time.Duration) string {
 		objectiveReplacer{
 			metric:   o.Indicator.BoolGauge.Name,
 			matchers: matchers,
+			offset:   o.Indicator.BoolGauge.OriginalOffset,
 			grouping: o.Grouping(),
 			window:   timerange,
 		}.replace(expr)
@@ -666,7 +690,7 @@ func (o Objective) RequestRange(timerange time.Duration) string {
 func (o Objective) ErrorsRange(timerange time.Duration) string {
 	switch o.IndicatorType() {
 	case Ratio:
-		expr, err := parser.ParseExpr(`sum by (group) (rate(errorMetric{matchers="errors"}[1s])) / scalar(sum(rate(metric{matchers="total"}[1s]))) > 0`)
+		expr, err := parser.ParseExpr(`sum by (group) (rate(errorMetric{matchers="errors"}[1s] offset 2ms)) / scalar(sum(rate(metric{matchers="total"}[1s] offset 1ms))) > 0`)
 		if err != nil {
 			return err.Error()
 		}
@@ -688,8 +712,10 @@ func (o Objective) ErrorsRange(timerange time.Duration) string {
 		objectiveReplacer{
 			metric:        o.Indicator.Ratio.Total.Name,
 			matchers:      matchers,
+			offset:        o.Indicator.Ratio.Total.OriginalOffset,
 			errorMetric:   o.Indicator.Ratio.Errors.Name,
 			errorMatchers: errorMatchers,
+			errorOffset:   o.Indicator.Ratio.Errors.OriginalOffset,
 			grouping: groupingLabels(
 				errorMatchers,
 				matchers,
@@ -699,7 +725,7 @@ func (o Objective) ErrorsRange(timerange time.Duration) string {
 
 		return expr.String()
 	case Latency:
-		expr, err := parser.ParseExpr(`(sum(rate(metric{matchers="total"}[1s])) -  sum(rate(errorMetric{matchers="errors"}[1s]))) / sum(rate(metric{matchers="total"}[1s]))`)
+		expr, err := parser.ParseExpr(`(sum(rate(metric{matchers="total"}[1s] offset 1ms)) -  sum(rate(errorMetric{matchers="errors"}[1s] offset 2ms))) / sum(rate(metric{matchers="total"}[1s] offset 1ms))`)
 		if err != nil {
 			return err.Error()
 		}
@@ -707,14 +733,16 @@ func (o Objective) ErrorsRange(timerange time.Duration) string {
 		objectiveReplacer{
 			metric:        o.Indicator.Latency.Total.Name,
 			matchers:      o.Indicator.Latency.Total.LabelMatchers,
+			offset:        o.Indicator.Latency.Total.OriginalOffset,
 			errorMetric:   o.Indicator.Latency.Success.Name,
 			errorMatchers: o.Indicator.Latency.Success.LabelMatchers,
+			errorOffset:   o.Indicator.Latency.Success.OriginalOffset,
 			window:        timerange,
 		}.replace(expr)
 
 		return expr.String()
 	case LatencyNative:
-		expr, err := parser.ParseExpr(`1 - sum(histogram_fraction(0,0.696969, rate(metric{matchers="total"}[1s])))`)
+		expr, err := parser.ParseExpr(`1 - sum(histogram_fraction(0,0.696969, rate(metric{matchers="total"}[1s] offset 1ms)))`)
 		if err != nil {
 			return err.Error()
 		}
@@ -722,13 +750,14 @@ func (o Objective) ErrorsRange(timerange time.Duration) string {
 		objectiveReplacer{
 			metric:   o.Indicator.LatencyNative.Total.Name,
 			matchers: o.Indicator.LatencyNative.Total.LabelMatchers,
+			offset:   o.Indicator.LatencyNative.Total.OriginalOffset,
 			window:   timerange,
 			target:   time.Duration(o.Indicator.LatencyNative.Latency).Seconds(),
 		}.replace(expr)
 
 		return expr.String()
 	case BoolGauge:
-		expr, err := parser.ParseExpr(`100 * sum by (group) ((count_over_time(metric{matchers="total"}[1s]) - sum_over_time(metric{matchers="total"}[1s]))) / sum by(group) (count_over_time(metric{matchers="total"}[1s]))`)
+		expr, err := parser.ParseExpr(`100 * sum by (group) ((count_over_time(metric{matchers="total"}[1s] offset 1ms) - sum_over_time(metric{matchers="total"}[1s] offset 1ms))) / sum by(group) (count_over_time(metric{matchers="total"}[1s] offset 1ms))`)
 		if err != nil {
 			return err.Error()
 		}
@@ -736,6 +765,7 @@ func (o Objective) ErrorsRange(timerange time.Duration) string {
 		objectiveReplacer{
 			metric:   o.Indicator.BoolGauge.Name,
 			matchers: o.Indicator.BoolGauge.LabelMatchers,
+			offset:   o.Indicator.BoolGauge.OriginalOffset,
 			window:   timerange,
 		}.replace(expr)
 
@@ -748,7 +778,7 @@ func (o Objective) ErrorsRange(timerange time.Duration) string {
 func (o Objective) DurationRange(timerange time.Duration, percentile float64) string {
 	switch o.IndicatorType() {
 	case Latency:
-		expr, err := parser.ParseExpr(`histogram_quantile(0.420, sum by (le) (rate(errorMetric{matchers="errors"}[1s])))`)
+		expr, err := parser.ParseExpr(`histogram_quantile(0.420, sum by (le) (rate(errorMetric{matchers="errors"}[1s] offset 2ms)))`)
 		if err != nil {
 			return err.Error()
 		}
@@ -763,6 +793,7 @@ func (o Objective) DurationRange(timerange time.Duration, percentile float64) st
 		objectiveReplacer{
 			errorMetric:   o.Indicator.Latency.Success.Name,
 			errorMatchers: matchers,
+			errorOffset:   o.Indicator.Latency.Success.OriginalOffset,
 			window:        timerange,
 			grouping:      []string{labels.BucketLabel},
 			percentile:    percentile,
@@ -770,7 +801,7 @@ func (o Objective) DurationRange(timerange time.Duration, percentile float64) st
 
 		return expr.String()
 	case LatencyNative:
-		expr, err := parser.ParseExpr(`histogram_quantile(0.420, sum(rate(metric{matchers="total"}[1s])))`)
+		expr, err := parser.ParseExpr(`histogram_quantile(0.420, sum(rate(metric{matchers="total"}[1s] offset 1ms)))`)
 		if err != nil {
 			return err.Error()
 		}
@@ -778,6 +809,7 @@ func (o Objective) DurationRange(timerange time.Duration, percentile float64) st
 		objectiveReplacer{
 			metric:     o.Indicator.LatencyNative.Total.Name,
 			matchers:   o.Indicator.LatencyNative.Total.LabelMatchers,
+			offset:     o.Indicator.LatencyNative.Total.OriginalOffset,
 			grouping:   o.Indicator.LatencyNative.Grouping,
 			window:     timerange,
 			percentile: percentile,

--- a/slo/promql.go
+++ b/slo/promql.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
+	"k8s.io/utils/ptr"
 )
 
 // QueryTotal returns a PromQL query to get the total amount of requests served during the window.
@@ -559,18 +560,10 @@ func (r objectiveReplacer) replace(node parser.Node) {
 		}
 		if n.OriginalOffset == 2*time.Millisecond {
 			// 2ms is the placeholder for the errorOffset
-			if r.errorOffset != nil {
-				n.OriginalOffset = *r.errorOffset
-			} else {
-				n.OriginalOffset = 0
-			}
+			n.OriginalOffset = ptr.Deref(r.errorOffset, 0)
 		} else if n.OriginalOffset == 1*time.Millisecond {
 			// 1ms is the placeholder for the offset
-			if r.offset != nil {
-				n.OriginalOffset = *r.offset
-			} else {
-				n.OriginalOffset = 0
-			}
+			n.OriginalOffset = ptr.Deref(r.offset, 0)
 		} else {
 			n.OriginalOffset = 0
 		}

--- a/slo/promql_test.go
+++ b/slo/promql_test.go
@@ -9,11 +9,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 )
-
-func durationPtr(d time.Duration) *time.Duration {
-	return &d
-}
 
 var (
 	objectiveHTTPRatio = func() Objective {
@@ -48,8 +45,8 @@ var (
 	}
 	objectiveHTTPRatioOffset = func() Objective {
 		o := objectiveHTTPRatio()
-		o.Indicator.Ratio.Total.OriginalOffset = durationPtr(5 * time.Minute)
-		o.Indicator.Ratio.Errors.OriginalOffset = durationPtr(5 * time.Minute)
+		o.Indicator.Ratio.Total.OriginalOffset = ptr.To(5 * time.Minute)
+		o.Indicator.Ratio.Errors.OriginalOffset = ptr.To(5 * time.Minute)
 		return o
 	}
 	objectiveHTTPRatioGrouping = func() Objective {
@@ -105,8 +102,8 @@ var (
 	}
 	objectiveGRPCRatioOffset = func() Objective {
 		o := objectiveGRPCRatio()
-		o.Indicator.Ratio.Total.OriginalOffset = durationPtr(5 * time.Minute)
-		o.Indicator.Ratio.Errors.OriginalOffset = durationPtr(5 * time.Minute)
+		o.Indicator.Ratio.Total.OriginalOffset = ptr.To(5 * time.Minute)
+		o.Indicator.Ratio.Errors.OriginalOffset = ptr.To(5 * time.Minute)
 		return o
 	}
 	objectiveGRPCRatioGrouping = func() Objective {
@@ -164,13 +161,13 @@ var (
 	}
 	objectiveHTTPNativeLatencyOffset = func() Objective {
 		o := objectiveHTTPNativeLatency()
-		o.Indicator.LatencyNative.Total.OriginalOffset = durationPtr(5 * time.Minute)
+		o.Indicator.LatencyNative.Total.OriginalOffset = ptr.To(5 * time.Minute)
 		return o
 	}
 	objectiveHTTPLatencyOffset = func() Objective {
 		o := objectiveHTTPLatency()
-		o.Indicator.Latency.Total.OriginalOffset = durationPtr(5 * time.Minute)
-		o.Indicator.Latency.Success.OriginalOffset = durationPtr(5 * time.Minute)
+		o.Indicator.Latency.Total.OriginalOffset = ptr.To(5 * time.Minute)
+		o.Indicator.Latency.Success.OriginalOffset = ptr.To(5 * time.Minute)
 		return o
 	}
 	objectiveHTTPLatencyGrouping = func() Objective {
@@ -226,8 +223,8 @@ var (
 	}
 	objectiveGRPCLatencyOffset = func() Objective {
 		o := objectiveGRPCLatency()
-		o.Indicator.Latency.Total.OriginalOffset = durationPtr(5 * time.Minute)
-		o.Indicator.Latency.Success.OriginalOffset = durationPtr(5 * time.Minute)
+		o.Indicator.Latency.Total.OriginalOffset = ptr.To(5 * time.Minute)
+		o.Indicator.Latency.Success.OriginalOffset = ptr.To(5 * time.Minute)
 		return o
 	}
 	objectiveGRPCLatencyGrouping = func() Objective {
@@ -264,8 +261,8 @@ var (
 	}
 	objectiveOperatorOffset = func() Objective {
 		o := objectiveOperator()
-		o.Indicator.Ratio.Total.OriginalOffset = durationPtr(5 * time.Minute)
-		o.Indicator.Ratio.Errors.OriginalOffset = durationPtr(5 * time.Minute)
+		o.Indicator.Ratio.Total.OriginalOffset = ptr.To(5 * time.Minute)
+		o.Indicator.Ratio.Errors.OriginalOffset = ptr.To(5 * time.Minute)
 		return o
 	}
 	objectiveOperatorGrouping = func() Objective {
@@ -383,7 +380,7 @@ var (
 	}
 	objectiveUpTargetsOffset = func() Objective {
 		o := objectiveUpTargets()
-		o.Indicator.BoolGauge.OriginalOffset = durationPtr(5 * time.Minute)
+		o.Indicator.BoolGauge.OriginalOffset = ptr.To(5 * time.Minute)
 		return o
 	}
 	objectiveUpTargetsGroupingRegex = func() Objective {

--- a/slo/rules_test.go
+++ b/slo/rules_test.go
@@ -71,6 +71,62 @@ func TestObjective_Burnrates(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "http-ratio-offset",
+		slo:  objectiveHTTPRatioOffset(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-http-errors",
+			Interval: monitoringDuration("30s"),
+			Rules: []monitoringv1.Rule{{
+				Record: "http_requests:burnrate5m",
+				Expr:   intstr.FromString(`sum(rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[5m] offset 5m)) / sum(rate(http_requests_total{job="thanos-receive-default"}[5m] offset 5m))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Record: "http_requests:burnrate30m",
+				Expr:   intstr.FromString(`sum(rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[30m] offset 5m)) / sum(rate(http_requests_total{job="thanos-receive-default"}[30m] offset 5m))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Record: "http_requests:burnrate1h",
+				Expr:   intstr.FromString(`sum(rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[1h] offset 5m)) / sum(rate(http_requests_total{job="thanos-receive-default"}[1h] offset 5m))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Record: "http_requests:burnrate2h",
+				Expr:   intstr.FromString(`sum(rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[2h] offset 5m)) / sum(rate(http_requests_total{job="thanos-receive-default"}[2h] offset 5m))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Record: "http_requests:burnrate6h",
+				Expr:   intstr.FromString(`sum(rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[6h] offset 5m)) / sum(rate(http_requests_total{job="thanos-receive-default"}[6h] offset 5m))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Record: "http_requests:burnrate1d",
+				Expr:   intstr.FromString(`sum(rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[1d] offset 5m)) / sum(rate(http_requests_total{job="thanos-receive-default"}[1d] offset 5m))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Record: "http_requests:burnrate4d",
+				Expr:   intstr.FromString(`sum(rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[4d] offset 5m)) / sum(rate(http_requests_total{job="thanos-receive-default"}[4d] offset 5m))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("2m0s"),
+				Expr:   intstr.FromString(`http_requests:burnrate5m{job="thanos-receive-default",slo="monitoring-http-errors"} > (14 * (1-0.99)) and http_requests:burnrate1h{job="thanos-receive-default",slo="monitoring-http-errors"} > (14 * (1-0.99))`),
+				Labels: map[string]string{"severity": "critical", "job": "thanos-receive-default", "long": "1h", "slo": "monitoring-http-errors", "short": "5m", "exhaustion": "2d"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("15m0s"),
+				Expr:   intstr.FromString(`http_requests:burnrate30m{job="thanos-receive-default",slo="monitoring-http-errors"} > (7 * (1-0.99)) and http_requests:burnrate6h{job="thanos-receive-default",slo="monitoring-http-errors"} > (7 * (1-0.99))`),
+				Labels: map[string]string{"severity": "critical", "job": "thanos-receive-default", "long": "6h", "slo": "monitoring-http-errors", "short": "30m", "exhaustion": "4d"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("1h0m0s"),
+				Expr:   intstr.FromString(`http_requests:burnrate2h{job="thanos-receive-default",slo="monitoring-http-errors"} > (2 * (1-0.99)) and http_requests:burnrate1d{job="thanos-receive-default",slo="monitoring-http-errors"} > (2 * (1-0.99))`),
+				Labels: map[string]string{"severity": "warning", "job": "thanos-receive-default", "long": "1d", "slo": "monitoring-http-errors", "short": "2h", "exhaustion": "2w"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("3h0m0s"),
+				Expr:   intstr.FromString(`http_requests:burnrate6h{job="thanos-receive-default",slo="monitoring-http-errors"} > (1 * (1-0.99)) and http_requests:burnrate4d{job="thanos-receive-default",slo="monitoring-http-errors"} > (1 * (1-0.99))`),
+				Labels: map[string]string{"severity": "warning", "job": "thanos-receive-default", "long": "4d", "slo": "monitoring-http-errors", "short": "6h", "exhaustion": "4w"},
+			}},
+		},
+	}, {
 		name: "http-ratio-grouping",
 		slo:  objectiveHTTPRatioGrouping(),
 		rules: monitoringv1.RuleGroup{
@@ -239,6 +295,62 @@ func TestObjective_Burnrates(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "grpc-errors-offset",
+		slo:  objectiveGRPCRatioOffset(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-grpc-errors",
+			Interval: monitoringDuration("30s"),
+			Rules: []monitoringv1.Rule{{
+				Record: "grpc_server_handled:burnrate5m",
+				Expr:   intstr.FromString(`sum(rate(grpc_server_handled_total{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[5m] offset 5m)) / sum(rate(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[5m] offset 5m))`),
+				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors"},
+			}, {
+				Record: "grpc_server_handled:burnrate30m",
+				Expr:   intstr.FromString(`sum(rate(grpc_server_handled_total{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[30m] offset 5m)) / sum(rate(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[30m] offset 5m))`),
+				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors"},
+			}, {
+				Record: "grpc_server_handled:burnrate1h",
+				Expr:   intstr.FromString(`sum(rate(grpc_server_handled_total{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1h] offset 5m)) / sum(rate(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1h] offset 5m))`),
+				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors"},
+			}, {
+				Record: "grpc_server_handled:burnrate2h",
+				Expr:   intstr.FromString(`sum(rate(grpc_server_handled_total{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[2h] offset 5m)) / sum(rate(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[2h] offset 5m))`),
+				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors"},
+			}, {
+				Record: "grpc_server_handled:burnrate6h",
+				Expr:   intstr.FromString(`sum(rate(grpc_server_handled_total{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[6h] offset 5m)) / sum(rate(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[6h] offset 5m))`),
+				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors"},
+			}, {
+				Record: "grpc_server_handled:burnrate1d",
+				Expr:   intstr.FromString(`sum(rate(grpc_server_handled_total{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1d] offset 5m)) / sum(rate(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1d] offset 5m))`),
+				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors"},
+			}, {
+				Record: "grpc_server_handled:burnrate4d",
+				Expr:   intstr.FromString(`sum(rate(grpc_server_handled_total{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4d] offset 5m)) / sum(rate(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4d] offset 5m))`),
+				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				Expr:   intstr.FromString(`grpc_server_handled:burnrate5m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-errors"} > (14 * (1-0.999)) and grpc_server_handled:burnrate1h{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-errors"} > (14 * (1-0.999))`),
+				For:    monitoringDuration("2m0s"),
+				Labels: map[string]string{"severity": "critical", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors", "short": "5m", "long": "1h", "exhaustion": "2d"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				Expr:   intstr.FromString(`grpc_server_handled:burnrate30m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-errors"} > (7 * (1-0.999)) and grpc_server_handled:burnrate6h{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-errors"} > (7 * (1-0.999))`),
+				For:    monitoringDuration("15m0s"),
+				Labels: map[string]string{"severity": "critical", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors", "short": "30m", "long": "6h", "exhaustion": "4d"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				Expr:   intstr.FromString(`grpc_server_handled:burnrate2h{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-errors"} > (2 * (1-0.999)) and grpc_server_handled:burnrate1d{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-errors"} > (2 * (1-0.999))`),
+				For:    monitoringDuration("1h0m0s"),
+				Labels: map[string]string{"severity": "warning", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors", "short": "2h", "long": "1d", "exhaustion": "2w"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				Expr:   intstr.FromString(`grpc_server_handled:burnrate6h{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-errors"} > (1 * (1-0.999)) and grpc_server_handled:burnrate4d{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-errors"} > (1 * (1-0.999))`),
+				For:    monitoringDuration("3h0m0s"),
+				Labels: map[string]string{"severity": "warning", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors", "short": "6h", "long": "4d", "exhaustion": "4w"},
+			}},
+		},
+	}, {
 		name: "grpc-errors-grouping",
 		slo:  objectiveGRPCRatioGrouping(),
 		rules: monitoringv1.RuleGroup{
@@ -351,6 +463,62 @@ func TestObjective_Burnrates(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "http-latency-offset",
+		slo:  objectiveHTTPLatencyOffset(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-http-latency",
+			Interval: monitoringDuration("30s"),
+			Rules: []monitoringv1.Rule{{
+				Record: "http_request_duration_seconds:burnrate5m",
+				Expr:   intstr.FromString(`(sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[5m] offset 5m)) - sum(rate(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[5m] offset 5m))) / sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[5m] offset 5m))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:burnrate30m",
+				Expr:   intstr.FromString(`(sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[30m] offset 5m)) - sum(rate(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[30m] offset 5m))) / sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[30m] offset 5m))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:burnrate1h",
+				Expr:   intstr.FromString(`(sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[1h] offset 5m)) - sum(rate(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[1h] offset 5m))) / sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[1h] offset 5m))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:burnrate2h",
+				Expr:   intstr.FromString(`(sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[2h] offset 5m)) - sum(rate(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[2h] offset 5m))) / sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[2h] offset 5m))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:burnrate6h",
+				Expr:   intstr.FromString(`(sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[6h] offset 5m)) - sum(rate(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[6h] offset 5m))) / sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[6h] offset 5m))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:burnrate1d",
+				Expr:   intstr.FromString(`(sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[1d] offset 5m)) - sum(rate(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[1d] offset 5m))) / sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[1d] offset 5m))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:burnrate4d",
+				Expr:   intstr.FromString(`(sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[4d] offset 5m)) - sum(rate(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[4d] offset 5m))) / sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[4d] offset 5m))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("2m"),
+				Expr:   intstr.FromString(`http_request_duration_seconds:burnrate5m{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (14 * (1-0.995)) and http_request_duration_seconds:burnrate1h{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (14 * (1-0.995))`),
+				Labels: map[string]string{"severity": "critical", "long": "1h", "job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency", "short": "5m", "exhaustion": "2d"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("15m"),
+				Expr:   intstr.FromString(`http_request_duration_seconds:burnrate30m{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (7 * (1-0.995)) and http_request_duration_seconds:burnrate6h{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (7 * (1-0.995))`),
+				Labels: map[string]string{"severity": "critical", "long": "6h", "job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency", "short": "30m", "exhaustion": "4d"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("1h"),
+				Expr:   intstr.FromString(`http_request_duration_seconds:burnrate2h{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (2 * (1-0.995)) and http_request_duration_seconds:burnrate1d{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (2 * (1-0.995))`),
+				Labels: map[string]string{"severity": "warning", "long": "1d", "job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency", "short": "2h", "exhaustion": "2w"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("3h"),
+				Expr:   intstr.FromString(`http_request_duration_seconds:burnrate6h{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (1 * (1-0.995)) and http_request_duration_seconds:burnrate4d{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (1 * (1-0.995))`),
+				Labels: map[string]string{"severity": "warning", "long": "4d", "job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency", "short": "6h", "exhaustion": "4w"},
+			}},
+		},
+	}, {
 		name: "http-latency-native",
 		slo:  objectiveHTTPNativeLatency(),
 		rules: monitoringv1.RuleGroup{
@@ -383,6 +551,62 @@ func TestObjective_Burnrates(t *testing.T) {
 			}, {
 				Record: "http_request_duration_seconds:burnrate4d",
 				Expr:   intstr.FromString(`1 - histogram_fraction(0, 1, rate(http_request_duration_seconds{code=~"2..",job="metrics-service-thanos-receive-default"}[4d]))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("2m"),
+				Expr:   intstr.FromString(`http_request_duration_seconds:burnrate5m{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (14 * (1-0.995)) and http_request_duration_seconds:burnrate1h{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (14 * (1-0.995))`),
+				Labels: map[string]string{"severity": "critical", "long": "1h", "job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency", "short": "5m", "exhaustion": "2d"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("15m"),
+				Expr:   intstr.FromString(`http_request_duration_seconds:burnrate30m{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (7 * (1-0.995)) and http_request_duration_seconds:burnrate6h{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (7 * (1-0.995))`),
+				Labels: map[string]string{"severity": "critical", "long": "6h", "job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency", "short": "30m", "exhaustion": "4d"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("1h"),
+				Expr:   intstr.FromString(`http_request_duration_seconds:burnrate2h{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (2 * (1-0.995)) and http_request_duration_seconds:burnrate1d{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (2 * (1-0.995))`),
+				Labels: map[string]string{"severity": "warning", "long": "1d", "job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency", "short": "2h", "exhaustion": "2w"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("3h"),
+				Expr:   intstr.FromString(`http_request_duration_seconds:burnrate6h{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (1 * (1-0.995)) and http_request_duration_seconds:burnrate4d{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"} > (1 * (1-0.995))`),
+				Labels: map[string]string{"severity": "warning", "long": "4d", "job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency", "short": "6h", "exhaustion": "4w"},
+			}},
+		},
+	}, {
+		name: "http-latency-native-offset",
+		slo:  objectiveHTTPNativeLatencyOffset(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-http-latency",
+			Interval: monitoringDuration("30s"),
+			Rules: []monitoringv1.Rule{{
+				Record: "http_request_duration_seconds:burnrate5m",
+				Expr:   intstr.FromString(`1 - histogram_fraction(0, 1, rate(http_request_duration_seconds{code=~"2..",job="metrics-service-thanos-receive-default"}[5m] offset 5m))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:burnrate30m",
+				Expr:   intstr.FromString(`1 - histogram_fraction(0, 1, rate(http_request_duration_seconds{code=~"2..",job="metrics-service-thanos-receive-default"}[30m] offset 5m))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:burnrate1h",
+				Expr:   intstr.FromString(`1 - histogram_fraction(0, 1, rate(http_request_duration_seconds{code=~"2..",job="metrics-service-thanos-receive-default"}[1h] offset 5m))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:burnrate2h",
+				Expr:   intstr.FromString(`1 - histogram_fraction(0, 1, rate(http_request_duration_seconds{code=~"2..",job="metrics-service-thanos-receive-default"}[2h] offset 5m))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:burnrate6h",
+				Expr:   intstr.FromString(`1 - histogram_fraction(0, 1, rate(http_request_duration_seconds{code=~"2..",job="metrics-service-thanos-receive-default"}[6h] offset 5m))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:burnrate1d",
+				Expr:   intstr.FromString(`1 - histogram_fraction(0, 1, rate(http_request_duration_seconds{code=~"2..",job="metrics-service-thanos-receive-default"}[1d] offset 5m))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:burnrate4d",
+				Expr:   intstr.FromString(`1 - histogram_fraction(0, 1, rate(http_request_duration_seconds{code=~"2..",job="metrics-service-thanos-receive-default"}[4d] offset 5m))`),
 				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
 			}, {
 				Alert:  "ErrorBudgetBurn",
@@ -575,6 +799,62 @@ func TestObjective_Burnrates(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "grpc-latency-offset",
+		slo:  objectiveGRPCLatencyOffset(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-grpc-latency",
+			Interval: monitoringDuration("30s"),
+			Rules: []monitoringv1.Rule{{
+				Record: "grpc_server_handling_seconds:burnrate1m",
+				Expr:   intstr.FromString(`(sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1m] offset 5m)) - sum(rate(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1m] offset 5m))) / sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1m] offset 5m))`),
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore"},
+			}, {
+				Record: "grpc_server_handling_seconds:burnrate8m",
+				Expr:   intstr.FromString(`(sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[8m] offset 5m)) - sum(rate(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[8m] offset 5m))) / sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[8m] offset 5m))`),
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore"},
+			}, {
+				Record: "grpc_server_handling_seconds:burnrate15m",
+				Expr:   intstr.FromString(`(sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[15m] offset 5m)) - sum(rate(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[15m] offset 5m))) / sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[15m] offset 5m))`),
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore"},
+			}, {
+				Record: "grpc_server_handling_seconds:burnrate30m",
+				Expr:   intstr.FromString(`(sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[30m] offset 5m)) - sum(rate(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[30m] offset 5m))) / sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[30m] offset 5m))`),
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore"},
+			}, {
+				Record: "grpc_server_handling_seconds:burnrate1h30m",
+				Expr:   intstr.FromString(`(sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1h30m] offset 5m)) - sum(rate(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1h30m] offset 5m))) / sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1h30m] offset 5m))`),
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore"},
+			}, {
+				Record: "grpc_server_handling_seconds:burnrate6h",
+				Expr:   intstr.FromString(`(sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[6h] offset 5m)) - sum(rate(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[6h] offset 5m))) / sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[6h] offset 5m))`),
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore"},
+			}, {
+				Record: "grpc_server_handling_seconds:burnrate1d",
+				Expr:   intstr.FromString(`(sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1d] offset 5m)) - sum(rate(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1d] offset 5m))) / sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1d] offset 5m))`),
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				Expr:   intstr.FromString(`grpc_server_handling_seconds:burnrate1m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-latency"} > (14 * (1-0.995)) and grpc_server_handling_seconds:burnrate15m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-latency"} > (14 * (1-0.995))`),
+				For:    monitoringDuration("1m"),
+				Labels: map[string]string{"severity": "critical", "long": "15m", "short": "1m", "slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "exhaustion": "12h"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				Expr:   intstr.FromString(`grpc_server_handling_seconds:burnrate8m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-latency"} > (7 * (1-0.995)) and grpc_server_handling_seconds:burnrate1h30m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-latency"} > (7 * (1-0.995))`),
+				For:    monitoringDuration("4m"),
+				Labels: map[string]string{"severity": "critical", "long": "1h30m", "short": "8m", "slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "exhaustion": "1d"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				Expr:   intstr.FromString(`grpc_server_handling_seconds:burnrate30m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-latency"} > (2 * (1-0.995)) and grpc_server_handling_seconds:burnrate6h{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-latency"} > (2 * (1-0.995))`),
+				For:    monitoringDuration("15m"),
+				Labels: map[string]string{"severity": "warning", "long": "6h", "short": "30m", "slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "exhaustion": "3d12h"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				Expr:   intstr.FromString(`grpc_server_handling_seconds:burnrate1h30m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-latency"} > (1 * (1-0.995)) and grpc_server_handling_seconds:burnrate1d{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-latency"} > (1 * (1-0.995))`),
+				For:    monitoringDuration("45m"),
+				Labels: map[string]string{"severity": "warning", "long": "1d", "short": "1h30m", "slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "exhaustion": "1w"},
+			}},
+		},
+	}, {
 		name: "grpc-latency-grouping",
 		slo:  objectiveGRPCLatencyGrouping(),
 		rules: monitoringv1.RuleGroup{
@@ -663,6 +943,62 @@ func TestObjective_Burnrates(t *testing.T) {
 			}, {
 				Record: "prometheus_operator_reconcile_operations:burnrate2d",
 				Expr:   intstr.FromString(`sum(rate(prometheus_operator_reconcile_errors_total[2d])) / sum(rate(prometheus_operator_reconcile_operations_total[2d]))`),
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("1m0s"),
+				Expr:   intstr.FromString(`prometheus_operator_reconcile_operations:burnrate3m{slo="monitoring-prometheus-operator-errors"} > (14 * (1-0.99)) and prometheus_operator_reconcile_operations:burnrate30m{slo="monitoring-prometheus-operator-errors"} > (14 * (1-0.99))`),
+				Labels: map[string]string{"severity": "critical", "long": "30m", "slo": "monitoring-prometheus-operator-errors", "short": "3m", "exhaustion": "1d"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("8m0s"),
+				Expr:   intstr.FromString(`prometheus_operator_reconcile_operations:burnrate15m{slo="monitoring-prometheus-operator-errors"} > (7 * (1-0.99)) and prometheus_operator_reconcile_operations:burnrate3h{slo="monitoring-prometheus-operator-errors"} > (7 * (1-0.99))`),
+				Labels: map[string]string{"severity": "critical", "long": "3h", "slo": "monitoring-prometheus-operator-errors", "short": "15m", "exhaustion": "2d"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("30m0s"),
+				Expr:   intstr.FromString(`prometheus_operator_reconcile_operations:burnrate1h{slo="monitoring-prometheus-operator-errors"} > (2 * (1-0.99)) and prometheus_operator_reconcile_operations:burnrate12h{slo="monitoring-prometheus-operator-errors"} > (2 * (1-0.99))`),
+				Labels: map[string]string{"severity": "warning", "long": "12h", "slo": "monitoring-prometheus-operator-errors", "short": "1h", "exhaustion": "1w"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("1h30m0s"),
+				Expr:   intstr.FromString(`prometheus_operator_reconcile_operations:burnrate3h{slo="monitoring-prometheus-operator-errors"} > (1 * (1-0.99)) and prometheus_operator_reconcile_operations:burnrate2d{slo="monitoring-prometheus-operator-errors"} > (1 * (1-0.99))`),
+				Labels: map[string]string{"severity": "warning", "long": "2d", "slo": "monitoring-prometheus-operator-errors", "short": "3h", "exhaustion": "2w"},
+			}},
+		},
+	}, {
+		name: "operator-ratio-offset",
+		slo:  objectiveOperatorOffset(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-prometheus-operator-errors",
+			Interval: monitoringDuration("30s"),
+			Rules: []monitoringv1.Rule{{
+				Record: "prometheus_operator_reconcile_operations:burnrate3m",
+				Expr:   intstr.FromString(`sum(rate(prometheus_operator_reconcile_errors_total[3m] offset 5m)) / sum(rate(prometheus_operator_reconcile_operations_total[3m] offset 5m))`),
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
+			}, {
+				Record: "prometheus_operator_reconcile_operations:burnrate15m",
+				Expr:   intstr.FromString(`sum(rate(prometheus_operator_reconcile_errors_total[15m] offset 5m)) / sum(rate(prometheus_operator_reconcile_operations_total[15m] offset 5m))`),
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
+			}, {
+				Record: "prometheus_operator_reconcile_operations:burnrate30m",
+				Expr:   intstr.FromString(`sum(rate(prometheus_operator_reconcile_errors_total[30m] offset 5m)) / sum(rate(prometheus_operator_reconcile_operations_total[30m] offset 5m))`),
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
+			}, {
+				Record: "prometheus_operator_reconcile_operations:burnrate1h",
+				Expr:   intstr.FromString(`sum(rate(prometheus_operator_reconcile_errors_total[1h] offset 5m)) / sum(rate(prometheus_operator_reconcile_operations_total[1h] offset 5m))`),
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
+			}, {
+				Record: "prometheus_operator_reconcile_operations:burnrate3h",
+				Expr:   intstr.FromString(`sum(rate(prometheus_operator_reconcile_errors_total[3h] offset 5m)) / sum(rate(prometheus_operator_reconcile_operations_total[3h] offset 5m))`),
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
+			}, {
+				Record: "prometheus_operator_reconcile_operations:burnrate12h",
+				Expr:   intstr.FromString(`sum(rate(prometheus_operator_reconcile_errors_total[12h] offset 5m)) / sum(rate(prometheus_operator_reconcile_operations_total[12h] offset 5m))`),
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
+			}, {
+				Record: "prometheus_operator_reconcile_operations:burnrate2d",
+				Expr:   intstr.FromString(`sum(rate(prometheus_operator_reconcile_errors_total[2d] offset 5m)) / sum(rate(prometheus_operator_reconcile_operations_total[2d] offset 5m))`),
 				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
 			}, {
 				Alert:  "ErrorBudgetBurn",
@@ -1095,6 +1431,62 @@ func TestObjective_Burnrates(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "prometheus-up-targets-offset",
+		slo:  objectiveUpTargetsOffset(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "up-targets",
+			Interval: monitoringDuration("30s"),
+			Rules: []monitoringv1.Rule{{
+				Record: "up:burnrate5m",
+				Expr:   intstr.FromString(`(sum(count_over_time(up[5m] offset 5m)) - sum(sum_over_time(up[5m] offset 5m))) / sum(count_over_time(up[5m] offset 5m))`),
+				Labels: map[string]string{"slo": "up-targets"},
+			}, {
+				Record: "up:burnrate30m",
+				Expr:   intstr.FromString(`(sum(count_over_time(up[30m] offset 5m)) - sum(sum_over_time(up[30m] offset 5m))) / sum(count_over_time(up[30m] offset 5m))`),
+				Labels: map[string]string{"slo": "up-targets"},
+			}, {
+				Record: "up:burnrate1h",
+				Expr:   intstr.FromString(`(sum(count_over_time(up[1h] offset 5m)) - sum(sum_over_time(up[1h] offset 5m))) / sum(count_over_time(up[1h] offset 5m))`),
+				Labels: map[string]string{"slo": "up-targets"},
+			}, {
+				Record: "up:burnrate2h",
+				Expr:   intstr.FromString(`(sum(count_over_time(up[2h] offset 5m)) - sum(sum_over_time(up[2h] offset 5m))) / sum(count_over_time(up[2h] offset 5m))`),
+				Labels: map[string]string{"slo": "up-targets"},
+			}, {
+				Record: "up:burnrate6h",
+				Expr:   intstr.FromString(`(sum(count_over_time(up[6h] offset 5m)) - sum(sum_over_time(up[6h] offset 5m))) / sum(count_over_time(up[6h] offset 5m))`),
+				Labels: map[string]string{"slo": "up-targets"},
+			}, {
+				Record: "up:burnrate1d",
+				Expr:   intstr.FromString(`(sum(count_over_time(up[1d] offset 5m)) - sum(sum_over_time(up[1d] offset 5m))) / sum(count_over_time(up[1d] offset 5m))`),
+				Labels: map[string]string{"slo": "up-targets"},
+			}, {
+				Record: "up:burnrate4d",
+				Expr:   intstr.FromString(`(sum(count_over_time(up[4d] offset 5m)) - sum(sum_over_time(up[4d] offset 5m))) / sum(count_over_time(up[4d] offset 5m))`),
+				Labels: map[string]string{"slo": "up-targets"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("2m"),
+				Expr:   intstr.FromString(`up:burnrate5m{slo="up-targets"} > (14 * (1-0.99)) and up:burnrate1h{slo="up-targets"} > (14 * (1-0.99))`),
+				Labels: map[string]string{"severity": "critical", "long": "1h", "short": "5m", "slo": "up-targets", "exhaustion": "2d"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("15m"),
+				Expr:   intstr.FromString(`up:burnrate30m{slo="up-targets"} > (7 * (1-0.99)) and up:burnrate6h{slo="up-targets"} > (7 * (1-0.99))`),
+				Labels: map[string]string{"severity": "critical", "long": "6h", "slo": "up-targets", "short": "30m", "exhaustion": "4d"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("1h"),
+				Expr:   intstr.FromString(`up:burnrate2h{slo="up-targets"} > (2 * (1-0.99)) and up:burnrate1d{slo="up-targets"} > (2 * (1-0.99))`),
+				Labels: map[string]string{"severity": "warning", "long": "1d", "slo": "up-targets", "short": "2h", "exhaustion": "2w"},
+			}, {
+				Alert:  "ErrorBudgetBurn",
+				For:    monitoringDuration("3h"),
+				Expr:   intstr.FromString(`up:burnrate6h{slo="up-targets"} > (1 * (1-0.99)) and up:burnrate4d{slo="up-targets"} > (1 * (1-0.99))`),
+				Labels: map[string]string{"severity": "warning", "long": "4d", "slo": "up-targets", "short": "6h", "exhaustion": "4w"},
+			}},
+		},
+	}, {
 		name: "prometheus-up-targets-grouping-regex",
 		slo:  objectiveUpTargetsGroupingRegex(),
 		rules: monitoringv1.RuleGroup{
@@ -1152,7 +1544,7 @@ func TestObjective_Burnrates(t *testing.T) {
 		},
 	}}
 
-	require.Len(t, testcases, 21)
+	require.Len(t, testcases, 28)
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1374,7 +1766,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Record: "http_request_duration_seconds:increase4w",
 				Expr:   intstr.FromString(`histogram_fraction(0, 1, increase(http_request_duration_seconds{code=~"2..",job="metrics-service-thanos-receive-default"}[4w])) * histogram_count(increase(http_request_duration_seconds{code=~"2..",job="metrics-service-thanos-receive-default"}[4w]))`),
 				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency", "le": "1"},
-				//}, {
+				// }, {
 				//	Alert:  "SLOMetricAbsent",
 				//	Expr:   intstr.FromString(`absent(http_request_duration_seconds{code=~"2..",job="metrics-service-thanos-receive-default"}) == 1`),
 				//	For:    monitoringDuration("2m"),

--- a/slo/slo.go
+++ b/slo/slo.go
@@ -151,11 +151,12 @@ type Alerting struct {
 }
 
 type Metric struct {
-	Name          string
-	LabelMatchers []*labels.Matcher
+	Name           string
+	LabelMatchers  []*labels.Matcher
+	OriginalOffset *time.Duration
 }
 
 func (m Metric) Metric() string {
-	v := parser.VectorSelector{Name: m.Name, LabelMatchers: m.LabelMatchers}
+	v := parser.VectorSelector{Name: m.Name, LabelMatchers: m.LabelMatchers, OriginalOffset: *m.OriginalOffset}
 	return v.String()
 }


### PR DESCRIPTION
# Description
Add support for Prometheus [offset modifier](https://prometheus.io/docs/prometheus/latest/querying/basics/#offset-modifier) in indicator metric expressions.

# Use Case
AWS CloudWatch ELB metrics are reported with a 5-10 minute delay. A Prometheus recording rule is evaluated at the current time, at which you will never have AWS ELB metrics in your Prometheus.

This can be solved by applying an `offset 10m` to the metric. All PromQL statements that use the recording rules don't need to have the offset applied. When the offset is used in the metric for the recording rule, everything is already recorded with the defined offset.

The offset is not great for fast burning alerts but I prefer to have a slightly delayed but working SLO over no SLO. There can also be other use cases where users benefit from applying a (shorter) offset.

If no offset is provided, everything works as before.